### PR TITLE
Old issue #3 wasn't fixed for relative text format.

### DIFF
--- a/app.py
+++ b/app.py
@@ -225,8 +225,13 @@ while timestamp <= stop:
 
             # Relative timestamp format
             if settings['format'] == 'relative':
-                line = str(datetime.timedelta(seconds=messageTimestampInSeconds - start)) + ' ' + sender + ': ' + text + '\n'
-                printLine = '\033[94m' + str(datetime.timedelta(seconds=messageTimestampInSeconds-start)) + ' \033[92m'+ sender + '\033[0m' + ': ' + text
+                subtitleStart = str(datetime.timedelta(seconds=messageTimestampInSeconds - start))
+                
+                if len(subtitleStart) == 7:
+                    subtitleStart += '.000000'
+                
+                line = subtitleStart[:-3] + ' ' + sender + ': ' + text + '\n'
+                printLine = '\033[94m' + subtitleStart[:-3] + ' \033[92m'+ sender + '\033[0m' + ': ' + text
 
             # Subtitle formats
             if settings['format'] in {'srt', 'ass', 'ssa'}:

--- a/app.py
+++ b/app.py
@@ -225,13 +225,13 @@ while timestamp <= stop:
 
             # Relative timestamp format
             if settings['format'] == 'relative':
-                subtitleStart = str(datetime.timedelta(seconds=messageTimestampInSeconds - start))
+                messageRelativeTimestamp = str(datetime.timedelta(seconds=messageTimestampInSeconds - start))
                 
-                if len(subtitleStart) == 7:
-                    subtitleStart += '.000000'
+                if len(messageRelativeTimestamp) == 7:
+                    messageRelativeTimestamp += '.000000'
                 
-                line = subtitleStart[:-3] + ' ' + sender + ': ' + text + '\n'
-                printLine = '\033[94m' + subtitleStart[:-3] + ' \033[92m'+ sender + '\033[0m' + ': ' + text
+                line = messageRelativeTimestamp[:-3] + ' ' + sender + ': ' + text + '\n'
+                printLine = '\033[94m' + messageRelativeTimestamp[:-3] + ' \033[92m'+ sender + '\033[0m' + ': ' + text
 
             # Subtitle formats
             if settings['format'] in {'srt', 'ass', 'ssa'}:


### PR DESCRIPTION
Applied the same fix to the relative time output format as was done to the subtitle formats, padding the fractions of the second with zeros. Also the last 3 digits were always zero, truncated that.

Probably change `subtitleStart` to `messageStart` or something. I just copy and pasted it to make it work.