### PR TITLE
Fix video titles in JSON format

### DIFF
--- a/tcd/pipe.py
+++ b/tcd/pipe.py
@@ -58,6 +58,7 @@ class Pipe:
         """
 
         # Video title
+        video_data = dict(video_data)
         video_data['title'] = Pipe.get_valid_filename(video_data['title'])
 
         # Output directory and file


### PR DESCRIPTION
When using the `json` format, video titles have characters such as `:` and `'` stripped:

    $ tcd --video 497919915 --format json
    code review: dlloverflow's VPNMonitor (Python)
    [json] ./497919915.json
    $ jq .video.title 497919915.json
    "code review dlloverflows VPNMonitor (Python)"

This happens because Pipe.output (called on tcd/downloader.py line 92) mutates video.data before it's written to the JSON file.

Fix the bug by making Pipe.output not mutate its parameter object:

    $ python -m tcd --video 497919915 --format json
    code review: dlloverflow's VPNMonitor (Python)
    [json] ./497919915.json

    $ jq .video.title 497919915.json
    "code review: dlloverflow's VPNMonitor (Python)"