### PR TITLE
Update twitch-python dependency

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Petter Kraabøl
+Copyright (c) 2022 Petter Kraabøl
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Pipfile
+++ b/Pipfile
@@ -7,7 +7,7 @@ name = "pypi"
 requests = "2.27.1"
 python-dateutil = "2.8.2"
 pytz = "2022.1"
-twitch-python = "0.0.18"
+twitch-python = "0.0.20"
 
 [dev-packages]
 wheel = "0.37.1"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "73e9ad4e6b6824a2687ecd5cd027ce9d2b412e0bca95a0a4e60a5fafd8e18e17"
+            "sha256": "f766820a857c8d158c278f7acfc69a0af04e3a020ee1e10be97b07db72010c38"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -81,11 +81,11 @@
         },
         "twitch-python": {
             "hashes": [
-                "sha256:b0b02abdd33458e4ffabc632aa6a6779f3599e188819632551353b6c5553f5c5",
-                "sha256:b2b05ec15c7a081e1eaa2141c8d5084a1aeaaca7c25c34cbce46ce88877b94bc"
+                "sha256:6e09d7210b8e0abb6892767d722079eb35b14c29e770cdb4df64d569ecbaa17c",
+                "sha256:8fb28e8484ee8151230998a249f72c878c54fe54bedfa5fbc19f4118b6a5afde"
             ],
             "index": "pypi",
-            "version": "==0.0.19"
+            "version": "==0.0.20"
         },
         "urllib3": {
             "hashes": [

--- a/setup.py
+++ b/setup.py
@@ -8,9 +8,9 @@ this_directory = os.path.abspath(os.path.dirname(__file__))
 with open(os.path.join(this_directory, 'readme.md'), encoding='utf-8') as f:
     readme = f.read()
 
-requirements = ['requests>=2.23.0', 'twitch-python>=0.0.18', 'pytz>=2020.1', 'python-dateutil>=2.8.1']
-test_requirements = ['twine>=3.1.1', 'wheel>=0.34.2']
-setup_requirements = ['pipenv>=2020.5.28', 'setuptools>=47.1.1']
+requirements = ['requests==2.27.1', 'twitch-python==0.0.20', 'pytz==2022.1', 'python-dateutil==2.8.2']
+test_requirements = ['twine==4.0.0', 'wheel==0.37.1']
+setup_requirements = ['pipenv==2022.4.30', 'setuptools==62.1.']
 
 setup(
     author='Petter Kraabøl',
@@ -43,6 +43,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/PetterKraabol/Twitch-Chat-Downloader',
-    version='3.2.1',
+    version='3.2.2',
     zip_safe=True,
 )

--- a/tcd/__init__.py
+++ b/tcd/__init__.py
@@ -11,7 +11,7 @@ from .logger import Logger, Log
 from .settings import Settings
 
 __name__: str = 'tcd'
-__version__: str = '3.2.1'
+__version__: str = '3.2.2'
 __all__: List[Callable] = [Arguments, Settings, Downloader, Logger, Log]
 
 


### PR DESCRIPTION
Update twitch-python dependency to 0.0.20, which contains a fix for the video comments api.